### PR TITLE
Explicitly depend on inherits instead of using util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
-var util = require('util');
+var inherits = require('inherits');
 
 
 function RefreshableCache() {
@@ -185,6 +185,6 @@ function RefreshableCache() {
   };
 }
 
-util.inherits(RefreshableCache, EventEmitter);
+inherits(RefreshableCache, EventEmitter);
 
 module.exports = RefreshableCache;

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   },
   "scripts": {
     "test": "gulp test"
+  },
+  "dependencies": {
+    "inherits": "~2.0.1"
   }
 }


### PR DESCRIPTION
* util is quite heavy and bundling it with browserify adds a bunch of unnecessary weight
* inherits is a standalone implementation of util.inherits